### PR TITLE
Add enclave measurements and bump checkout action

### DIFF
--- a/checkout/action.yaml
+++ b/checkout/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
   - name: Checkout
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
     with:
       submodules: recursive
   - name: Set Git Safe Directory

--- a/enclave-measurements/action.yaml
+++ b/enclave-measurements/action.yaml
@@ -7,27 +7,29 @@ inputs:
 
 outputs:
   mrsigner:
-    value: ""
+    value: ${{ steps.mrsigner.outputs.value }}
     description: Hex value of MRSIGNER measurement
   mrenclave:
-    value: ""
+    value: ${{ steps.mrenclave.outputs.value }}
     description: Hex value of MRENCLAVE measurement
 
 runs:
   using: composite
   steps:
   - name: Get MRSIGNER
+    id: mrsigner
     shell: bash
     run: |
       mrsigner=$(sgx_sign dump -enclave "${{ inputs.enclave_so_path }}" -dumpfile /dev/stdout 2>&1 | grep -A 2 -m 1 "mrsigner->value" | grep -v "mrsigner->value" | sed -r 's/(0x|\s+)//g' | tr -d "\n")
 
       echo "${mrsigner}"
-      echo "mrsigner=${mrsigner}" >> ${GITHUB_OUTPUT}
+      echo "value=${mrsigner}" >> ${GITHUB_OUTPUT}
 
   - name: Get MRENCLAVE
+    id: mrenclave
     shell: bash
     run: |
       mrenclave=$(sgx_sign dump -enclave "${{ inputs.enclave_so_path }}" -dumpfile /dev/stdout | grep -A 2 -m 1 "enclave_hash.m" | grep -v "enclave_hash.m" | grep 0x | sed -r 's/(0x|\s+)//g' | tr -d "\n")
 
       echo "${mrenclave}"
-      echo "mrenclave=${mrenclave}" >> ${GITHUB_OUTPUT}
+      echo "value=${mrenclave}" >> ${GITHUB_OUTPUT}

--- a/enclave-measurements/action.yaml
+++ b/enclave-measurements/action.yaml
@@ -1,0 +1,33 @@
+name: Mobilecoin Enclave Measurements
+description: Output the the MRSIGNER/MRENCLAVE Hex values. Requires using the mobilecoin/rust-sgx-base image you built with.
+
+inputs:
+  enclave_so_path:
+    description: path to the enclave singed.so file
+
+outputs:
+  mrsigner:
+    value: ""
+    description: Hex value of MRSIGNER measurement
+  mrenclave:
+    value: ""
+    description: Hex value of MRENCLAVE measurement
+
+runs:
+  using: composite
+  steps:
+  - name: Get MRSIGNER
+    shell: bash
+    run: |
+      mrsigner=$(sgx_sign dump -enclave "${{ inputs.enclave_so_path }}" -dumpfile /dev/stdout 2>&1 | grep -A 2 -m 1 "mrsigner->value" | grep -v "mrsigner->value" | sed -r 's/(0x|\s+)//g' | tr -d "\n")
+
+      echo "${mrsigner}"
+      echo "mrsigner=${mrsigner}" >> ${GITHUB_OUTPUT}
+
+  - name: Get MRENCLAVE
+    shell: bash
+    run: |
+      mrenclave=$(sgx_sign dump -enclave "${{ inputs.enclave_so_path }}" -dumpfile /dev/stdout | grep -A 2 -m 1 "enclave_hash.m" | grep -v "enclave_hash.m" | grep 0x | sed -r 's/(0x|\s+)//g' | tr -d "\n")
+
+      echo "${mrenclave}"
+      echo "mrenclave=${mrenclave}" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
- bump github actions/checkout to v4
- Add action to get enclave measurements - does require running in mobilecoin/rust-sgx-base for access to sgx utilities.