### PR TITLE
Revert "create cache path directories"

### DIFF
--- a/cache-cargo-packages/action.yaml
+++ b/cache-cargo-packages/action.yaml
@@ -25,16 +25,6 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Create cache directories
-    shell: bash
-    run: |
-      read -r -d '' DIRS << EOF
-      ${{ inputs.path }}
-      EOF
-      for d in ${DIRS}
-      do
-          mkdir -p "${d}"
-      done
   - name: Cache rust build binaries
     id: rust_artifact_cache
     uses: actions/cache@v3

--- a/cache-go-binaries/action.yaml
+++ b/cache-go-binaries/action.yaml
@@ -23,16 +23,6 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Create cache directories
-    shell: bash
-    run: |
-      read -r -d '' DIRS << EOF
-      ${{ inputs.path }}
-      EOF
-      for d in ${DIRS}
-      do
-          mkdir -p "${d}"
-      done
   - name: Cache build binaries
     id: cache
     uses: actions/cache@v3

--- a/cache-rust-binaries/action.yaml
+++ b/cache-rust-binaries/action.yaml
@@ -23,16 +23,6 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Create cache directories
-    shell: bash
-    run: |
-      read -r -d '' DIRS << EOF
-      ${{ inputs.path }}
-      EOF
-      for d in ${DIRS}
-      do
-          mkdir -p "${d}"
-      done
   - name: Cache rust build binaries
     id: rust_artifact_cache
     uses: actions/cache@v3


### PR DESCRIPTION
Reverts mobilecoinofficial/gh-actions#7

In local testing the bash script created the directories just fine.  On the GHA run it failed.  I've already reverted the v0 and v0.0 tags. Revert until I have a chance to troubleshoot.