### PR TITLE
move this public repo to gh hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint-shell:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
         reporter: github-pr-review
 
   lint-actions:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
     needs:
     - lint-shell
     - lint-actions
-    runs-on: [self-hosted, Linux, small]
+    runs-on: ubuntu-22.04
     steps:
     - name: All Checks OK!
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   gh-release:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tag:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: ubuntu-22.04
     steps:
     # We need to use an external PAT here because GHA will not run downstream events if we use the built in token.
     - name: Checkout


### PR DESCRIPTION
Just use the GitHub hosted runners.  We don't need large runners for this.