### PR TITLE
Wrapers and cache

### DIFF
--- a/cache-rust-binaries/action.yaml
+++ b/cache-rust-binaries/action.yaml
@@ -26,6 +26,10 @@ runs:
   - name: Install zstd if needed
     uses: mobilecoinofficial/gh-actions/install-zstd@v0
 
+  - name: Create cache directory
+    shell: bash
+    run: mkdir -p ${{ inputs.path }}
+
   - name: Cache rust build binaries
     id: rust_artifact_cache
     uses: actions/cache@v3

--- a/gh-release/action.yaml
+++ b/gh-release/action.yaml
@@ -1,0 +1,67 @@
+name: GH Release
+description: Wrapper for softprops/action-gh-release
+
+inputs:
+  body:
+    description: "Note-worthy description of changes in release"
+    required: false
+  body_path:
+    description: "Path to load note-worthy description of changes in release from"
+    required: false
+  name:
+    description: "Gives the release a custom name. Defaults to tag name"
+    required: false
+  tag_name:
+    description: "Gives a tag name. Defaults to github.GITHUB_REF"
+    required: false
+  draft:
+    description: "Creates a draft release. Defaults to false"
+    required: false
+  prerelease:
+    description: "Identify the release as a prerelease. Defaults to false"
+    required: false
+  files:
+    description: "Newline-delimited list of path globs for asset files to upload"
+    required: false
+  fail_on_unmatched_files:
+    description: "Fails if any of the `files` globs match nothing. Defaults to false"
+    required: false
+  repository:
+    description: "Repository to make releases against, in <owner>/<repo> format"
+    required: false
+  token:
+    description: "Authorized secret GitHub Personal Access Token. Defaults to github.token"
+    required: false
+    default: ${{ github.token }}
+  target_commitish:
+    description: "Commitish value that determines where the Git tag is created from. Can be any branch or commit SHA."
+    required: false
+  discussion_category_name:
+    description: "If specified, a discussion of the specified category is created and linked to the release. The value must be a category that already exists in the repository. If there is already a discussion linked to the release, this parameter is ignored."
+    required: false
+  generate_release_notes:
+    description: "Whether to automatically generate the name and body for this release. If name is specified, the specified name will be used; otherwise, a name will be automatically generated. If body is specified, the body will be pre-pended to the automatically generated notes."
+    required: false
+  append_body:
+    description: "Append to existing body instead of overwriting it. Default is false."
+    required: false
+
+runs:
+  using: composite
+  steps:
+  - name: Release
+    uses: softprops/action-gh-release@v1
+    with:
+      body: ${{ inputs.body }}
+      body_path: ${{ inputs.body_path }}
+      name: ${{ inputs.name }}
+      tag_name: ${{ inputs.tag_name }}
+      prerelease: ${{ inputs.prerelease }}
+      files: ${{ inputs.files }}
+      fail_on_unmatched_files: ${{ inputs.fail_on_unmatched_files }}
+      repository: ${{ inputs.repository }}
+      token: ${{ inputs.token }}
+      target_commitish: ${{ inputs.target_commitish }}
+      discussion_category_name: ${{ inputs.discussion_category_name }}
+      generate_release_notes: ${{ inputs.generate_release_notes }}
+      append_body: ${{ inputs.append_body }}

--- a/publish-buf/action.yaml
+++ b/publish-buf/action.yaml
@@ -1,0 +1,29 @@
+name: Publish to Buf
+description: Wrapper for publishing protos to buf.build
+
+inputs:
+  github_token:
+    description: Github token passed into setup to prevent api rate limiting
+    required: true
+  buf_token:
+    description: buf.build api token
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout
+    uses: mobilecoinofficial/gh-actions/checkout@v0
+
+  - name: Buf Setup
+    uses: bufbuild/buf-setup-action@v1.21.0
+    with:
+      github_token: ${{ inputs.github_token }}
+
+  - name: Publish Protobufs to Buf
+    uses: bufbuild/buf-push-action@v1
+    with:
+      # TODO: Reuse GH tag on buf when buf-push-action supports specifying
+      # it: https://github.com/bufbuild/buf-push-action/issues/20
+      input: api/proto
+      buf_token: ${{ inputs.buf_token }}

--- a/tag/action.yaml
+++ b/tag/action.yaml
@@ -1,0 +1,28 @@
+name: Bump Tag
+description: Wrapper for anothrNick/github-tag-action
+
+inputs:
+  github_token:
+    description: Github token passed into setup to prevent api rate limiting
+    required: true
+  with_v:
+    description: prepend 'v' to tag version
+    default: 'true'
+  default_bump:
+    description: bump major, minor or patch by default
+    default: patch
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout
+    uses: mobilecoinofficial/gh-actions/checkout@v0
+    with:
+      token: ${{ inputs.github_token }}
+
+  - name: Bump GitHub tag
+    uses: anothrNick/github-tag-action@v1
+    env:
+      GITHUB_TOKEN: ${{ inputs.github_token }}
+      WITH_V: ${{ inputs.with_v }}
+      DEFAULT_BUMP: ${{ inputs.default_bump }}

--- a/upload-artifact/action.yaml
+++ b/upload-artifact/action.yaml
@@ -1,0 +1,22 @@
+name: Upload Artifacts
+description: Wrapper for actions/upload-artifact
+
+inputs:
+  name:
+    description: Artifact name
+    required: true
+  path:
+    description: A file, directory or wildcard pattern that describes what to upload
+    required: true
+  retention-days:
+    description: Duration after which artifact will expire in days. 0 means using default retention.
+
+runs:
+  using: composite
+  steps:
+  - name: Upload binaries
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ inputs.name }}
+      path: ${{ inputs.path }}
+      retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
Wrappers to centrally maintain versions on:
- softprops/action-gh-release
- bufbuild/buf*
- actions/upload-artifact

Add a create dir step to cache action wrapper.