### PR TITLE
restore safe-dir step, built in doesn't work as expected

### DIFF
--- a/checkout/action.yaml
+++ b/checkout/action.yaml
@@ -39,4 +39,10 @@ runs:
       path: ${{ inputs.path }}
       ref: ${{ inputs.ref }}
       repository: ${{ inputs.repository }}
-      set-safe-directory: true
+      # set-safe-directory: true <- not sure what the point is since this doesn't persist beyond the "Checkout" step
+
+  - name: Set Git Safe Directory
+    shell: bash
+    run: |
+      git config --global --add safe.directory "$(pwd)"
+      git config --global -l --show-origin

--- a/checkout/action.yaml
+++ b/checkout/action.yaml
@@ -45,4 +45,3 @@ runs:
     shell: bash
     run: |
       git config --global --add safe.directory "$(pwd)"
-      git config --global -l --show-origin


### PR DESCRIPTION
Noticed that the latest version of checkout had a `set-safe-directory` option.  It sets a temporary `HOME` directory so it doesn't seem to persist beyond the "Checkout" step.

Restore the previous Set Git Safe Directory functionality 