### PR TITLE
update actions/cache to v4

### DIFF
--- a/cache-cargo-packages/action.yaml
+++ b/cache-cargo-packages/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
   - name: Cache rust build binaries
     id: rust_artifact_cache
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: ${{ inputs.path }}
       # Key is a hash of all the Cargo.toml and Cargo.lock files.

--- a/cache-go-binaries/action.yaml
+++ b/cache-go-binaries/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
   - name: Cache build binaries
     id: cache
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: ${{ inputs.path }}
       # Key is a hash of all the .go, .p files.

--- a/cache-rust-binaries/action.yaml
+++ b/cache-rust-binaries/action.yaml
@@ -32,7 +32,7 @@ runs:
 
   - name: Cache rust build binaries
     id: rust_artifact_cache
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: ${{ inputs.path }}
       # Key is a hash of all the .rs, .proto and Cargo.toml files.


### PR DESCRIPTION
actions/cache to v4 to remove node16 warnings

Changelog for actions/cache doesn't show any option changes.