### PR TITLE
bump softprops/action-gh-release to v2

### DIFF
--- a/gh-release/action.yaml
+++ b/gh-release/action.yaml
@@ -50,7 +50,7 @@ runs:
   using: composite
   steps:
   - name: Release
-    uses: softprops/action-gh-release@v1
+    uses: softprops/action-gh-release@v2
     with:
       body: ${{ inputs.body }}
       body_path: ${{ inputs.body_path }}


### PR DESCRIPTION
Bump softprops/action-gh-release to v2.  I believe this should fix some of the deprecated node version warnings.