### PR TITLE
disable docker post-build annotations and summary

### DIFF
--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -86,6 +86,10 @@ runs:
 
   - name: Publish to DockerHub
     uses: docker/build-push-action@v6
+    env:
+      DOCKER_BUILD_CHECKS_ANNOTATIONS: "false"
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     with:
       build-args: ${{ inputs.build_args }}
       context: ${{ inputs.context }}


### PR DESCRIPTION
Disable noisy summary and annotations.  https://github.com/docker/build-push-action?tab=readme-ov-file#environment-variables 