### PR TITLE
add optional outputs override

### DIFF
--- a/docker-merge-digests/action.yaml
+++ b/docker-merge-digests/action.yaml
@@ -1,0 +1,71 @@
+name: Mobilecoin Docker
+description: Standardized docker build and publish actions
+
+inputs:
+  digest_artifact_prefix:
+    description: Prefix for the artifact names to restore
+    required: false
+    default: ""
+  flavor:
+    description: New line separated list of docker meta flavor options
+    required: false
+    default: "latest=false"
+  images:
+    description: URL/Path to docker image registry
+    default: ""
+    required: false
+  tags:
+    description: New line separated list of tags for the docker image
+    required: false
+    default: ""
+  username:
+    description: docker registry user
+    default: ""
+    required: false
+  password:
+    description: docker registry password
+    default: ""
+    required: false
+
+outputs:
+  tags:
+    description: docker/meta-action tags
+    value: ${{ steps.docker_meta.output.tags }}
+
+runs:
+  using: composite
+  steps:
+  - name: Download digests
+    uses: mobilecoinofficial/gh-actions/download-artifact@v0
+    with:
+      path: /tmp/digests
+      pattern: ${{ inputs.digest_artifact_prefix }}*
+      merge-multiple: true
+
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v3
+
+  - name: Generate Docker Tags
+    id: docker_meta
+    uses: docker/metadata-action@v5
+    with:
+      flavor: ${{ inputs.flavor }}
+      images: ${{ inputs.images }}
+      tags: ${{ inputs.tags }}
+
+  - name: Login to DockerHub
+    if: inputs.username && inputs.password
+    uses: docker/login-action@v3
+    with:
+      username: ${{ inputs.username }}
+      password: ${{ inputs.password }}
+
+  - name: Create manifest list and push
+    shell: bash
+    working-directory: /tmp/digests
+    run: |
+      # Grab the tags from metadata-action ENV with jq
+      # Gather all the digests for the images pushed (names of empty files stored as artifacts)
+      # Push a manifest (tag) with all the digests to dockerhub
+      docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(printf '${{ inputs.images }}@sha256:%s ' *)

--- a/docker-merge-digests/action.yaml
+++ b/docker-merge-digests/action.yaml
@@ -1,11 +1,7 @@
-name: Mobilecoin Docker
-description: Standardized docker build and publish actions
+name: Docker Merge Digest
+description: This action takes a list of docker image digests and merges them into a manifest that we can tag and push to a registry. This is useful for creating a manifest list for multi-arch images. Digests are stored as an empty file attached as artifacts to the build by previous steps.
 
 inputs:
-  digest_artifact_prefix:
-    description: Prefix for the artifact names to restore
-    required: false
-    default: ""
   flavor:
     description: New line separated list of docker meta flavor options
     required: false
@@ -35,11 +31,17 @@ outputs:
 runs:
   using: composite
   steps:
+  - name: Parse Image Name
+    shell: bash
+    run: |
+      IMAGE_NAME=${{ inputs.images }}
+      echo "IMAGE_NAME=${IMAGE_NAME#*/}" >> "${GITHUB_ENV}"
+
   - name: Download digests
     uses: mobilecoinofficial/gh-actions/download-artifact@v0
     with:
       path: /tmp/digests
-      pattern: ${{ inputs.digest_artifact_prefix }}*
+      pattern: digests-${{ env.IMAGE_NAME }}*
       merge-multiple: true
 
   - name: Set up Docker Buildx

--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -53,6 +53,10 @@ inputs:
     description: override the image output methods https://docs.docker.com/build/exporters/
     required: false
     default: ""
+  save_digest:
+    description: save the docker image digest to an artifact
+    required: false
+    default: "false"
 
 outputs:
   tags:
@@ -108,3 +112,27 @@ runs:
       tags: ${{ inputs.outputs == '' && steps.docker_meta.outputs.tags || '' }}
       target: ${{ inputs.target }}
       outputs: ${{ inputs.outputs }}
+
+  - name: Parse Image Name
+    if: inputs.save_digest == 'true'
+    shell: bash
+    run: |
+      IMAGE_NAME=${{ inputs.images }}
+      echo "IMAGE_NAME=${IMAGE_NAME#*/}" >> "${GITHUB_ENV}"
+
+  - name: Export Digest
+    if: inputs.save_digest == 'true'
+    shell: bash
+    run: |
+      mkdir -p /tmp/digests
+      digest="${{ steps.build.outputs.digest }}"
+      touch "/tmp/digests/${digest#sha256:}"
+
+  - name: Upload Digests
+    if: inputs.save_digest == 'true'
+    uses: mobilecoinofficial/gh-actions/upload-artifact@v0
+    with:
+      name: digests-${{ env.IMAGE_NAME }}-${{ runner.arch }}
+      path: /tmp/digests/*
+      if-no-files-found: error
+      retention-days: 1

--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -17,8 +17,7 @@ inputs:
   flavor:
     description: New line separated list of docker meta flavor options
     required: false
-    default: |
-      latest=true
+    default: "latest=false"
   platforms:
     description: comma separated list of platforms to build for linux/amd64,linux/arm64
     default: ""
@@ -36,7 +35,8 @@ inputs:
     required: false
   tags:
     description: New line separated list of tags for the docker image
-    required: true
+    required: false
+    default: ""
   target:
     description: Sets the target stage to build in Dockerfile
     required: false
@@ -49,14 +49,21 @@ inputs:
     description: docker registry password
     default: ""
     required: false
+  outputs:
+    description: override the image output methods https://docs.docker.com/build/exporters/
+    required: false
+    default: ""
 
 outputs:
   tags:
     description: docker/meta-action tags
-    value: ${{ steps.docker_meta.tags }}
+    value: ${{ steps.docker_meta.output.tags }}
   pushed:
     description: was the docker image published to the registry
     value: ${{ inputs.push }}
+  digest:
+    description: docker image digest
+    value: ${{ steps.docker_build.outputs.digest }}
 
 runs:
   using: composite
@@ -85,6 +92,7 @@ runs:
       password: ${{ inputs.password }}
 
   - name: Publish to DockerHub
+    id: docker_build
     uses: docker/build-push-action@v6
     env:
       DOCKER_BUILD_CHECKS_ANNOTATIONS: "false"
@@ -97,5 +105,6 @@ runs:
       labels: ${{ steps.docker_meta.outputs.labels }}
       platforms: ${{ inputs.platforms }}
       push: ${{ inputs.push }}
-      tags: ${{ steps.docker_meta.outputs.tags }}
+      tags: ${{ inputs.outputs == '' && steps.docker_meta.outputs.tags || '' }}
       target: ${{ inputs.target }}
+      outputs: ${{ inputs.outputs }}

--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -67,7 +67,7 @@ outputs:
     value: ${{ inputs.push }}
   digest:
     description: docker image digest
-    value: ${{ steps.docker_build.outputs.digest }}
+    value: ${{ steps.build.outputs.digest }}
 
 runs:
   using: composite
@@ -96,7 +96,7 @@ runs:
       password: ${{ inputs.password }}
 
   - name: Publish to DockerHub
-    id: docker_build
+    id: build
     uses: docker/build-push-action@v6
     env:
       DOCKER_BUILD_CHECKS_ANNOTATIONS: "false"

--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -57,7 +57,7 @@ inputs:
 outputs:
   tags:
     description: docker/meta-action tags
-    value: ${{ steps.docker_meta.output.tags }}
+    value: ${{ steps.docker_meta.outputs.tags }}
   pushed:
     description: was the docker image published to the registry
     value: ${{ inputs.push }}

--- a/short-sha/action.yaml
+++ b/short-sha/action.yaml
@@ -1,0 +1,16 @@
+name: Short SHA
+description: Just spit out the short SHA (7) of the commit.
+
+outputs:
+  short_sha:
+    description: Short SHA (7) of the commit
+    value: ${{ steps.short_sha.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+  - name: Get short SHA
+    shell: bash
+    id: short_sha
+    run: |
+        echo "sha=sha-${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
- add docker build-push action raw `output` override option
- add docker image digest as output
- add action to merge various docker image digests into a manifest (tag) for multi-arch support.
- add simple helper action for getting the "short" SHA tag of a release.

This is improvements to gh-actions for doing multi-arch builds.

Ends up the process is more complex than I was hoping.  If you want to do multi-arch with discrete builders (not QEMU or cross compile) you need to first push the images without tags (just the sha256 digest), then you take all the digests and create a manifest that refences the digest and push that up do docker with a tag.  

This improves the docker action to allow a raw output override so we can push the bare images and adds a docker-merge-digests action to create the manifest and push up the tag.