### PR TITLE
make git submodules optional for linter actions

### DIFF
--- a/lint-actions/action.yaml
+++ b/lint-actions/action.yaml
@@ -1,11 +1,19 @@
 name: Lint GitHub Actions
 description: run actionlint with reviewdog
 
+inputs:
+  submodules:
+    description: true. false or recursive
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
   - name: Checkout
     uses: mobilecoinofficial/gh-actions/checkout@v0
+    with:
+      submodules: ${{ inputs.submodules }}
 
   - name: Run actionlint with reviewdog
     uses: reviewdog/action-actionlint@v1

--- a/lint-docker/action.yaml
+++ b/lint-docker/action.yaml
@@ -1,11 +1,19 @@
 name: Lint Docker
 description: Lint dockerfiles with hadolint and reviewdog
 
+inputs:
+  submodules:
+    description: true. false or recursive
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
   - name: Checkout
     uses: mobilecoinofficial/gh-actions/checkout@v0
+    with:
+      submodules: ${{ inputs.submodules }}
 
   - name: Install wget
     shell: bash

--- a/lint-helm/action.yaml
+++ b/lint-helm/action.yaml
@@ -1,13 +1,19 @@
 name: Lint Helm
 description: run helm lint
 
+inputs:
+  submodules:
+    description: true. false or recursive
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
   - name: Checkout
     uses: mobilecoinofficial/gh-actions/checkout@v0
     with:
-      submodules: false
+      submodules: ${{ inputs.submodules }}
 
   - name: Lint Helm
     uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/lint-shell/action.yaml
+++ b/lint-shell/action.yaml
@@ -1,11 +1,25 @@
 name: Lint Shell Scripts
 description: run shellcheck with reviewdog
 
+inputs:
+  submodules:
+    description: true. false or recursive
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
   - name: Checkout
     uses: mobilecoinofficial/gh-actions/checkout@v0
+    with:
+      submodules: ${{ inputs.submodules }}
+
+  - name: Install xz-utils
+    shell: bash
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y xz-utils
 
   - name: Run shellcheck with reviewdog
     uses: reviewdog/action-shellcheck@v1


### PR DESCRIPTION
Most of the time we only want to lint what is in the local repository.  Make pulling submodules optional and default to `false`.