### PR TITLE
pin upstream actions version to reduce supply-chain risks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,24 +17,24 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Run shellcheck with reviewdog
-      uses: reviewdog/action-shellcheck@v1
+      uses: reviewdog/action-shellcheck@5ebd09ddbe2ebb471646ce234c6c8dd18663ca7c # v1.30.0
       with:
-        fail_on_error: true
+        fail_level: error
         reporter: github-pr-review
 
   lint-actions:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Run actionlint with reviewdog
-      uses: reviewdog/action-actionlint@v1
+      uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
       with:
-        fail_on_error: true
+        fail_level: error
         reporter: github-pr-review
 
   # Have one noop job at the end that passes if all the other checks pass.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Create a GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       with:
         generate_release_notes: true

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,13 +15,13 @@ jobs:
     steps:
     # We need to use an external PAT here because GHA will not run downstream events if we use the built in token.
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         token: ${{ secrets.ACTIONS_TOKEN }}
 
     - name: Bump GitHub tag
       id: bump
-      uses: anothrNick/github-tag-action@1.71.0
+      uses: anothrNick/github-tag-action@f278d49d30cdd8775cc3e7dd00b5ee11686ee297 # v1.71.0
       env:
         GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
         WITH_V: 'true'

--- a/build-downstream-rust-repo/action.yaml
+++ b/build-downstream-rust-repo/action.yaml
@@ -53,7 +53,7 @@ runs:
 
   - name: Warn in PR if build fails
     if: env.BUILD_SUCCESS == 'no'
-    uses: actions/github-script@v7
+    uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
     with:
       script: |
         github.rest.issues.createComment({
@@ -65,7 +65,7 @@ runs:
 
   - name: Success in PR if build is good
     if: env.BUILD_SUCCESS == 'yes' && inputs.report_success == 'true'
-    uses: actions/github-script@v7
+    uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
     with:
       script: |
         github.rest.issues.createComment({

--- a/cache-cargo-packages/action.yaml
+++ b/cache-cargo-packages/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
   - name: Cache rust build binaries
     id: rust_artifact_cache
-    uses: actions/cache@v4
+    uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
     with:
       path: ${{ inputs.path }}
       # Key is a hash of all the Cargo.toml and Cargo.lock files.

--- a/cache-go-binaries/action.yaml
+++ b/cache-go-binaries/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
   - name: Cache build binaries
     id: cache
-    uses: actions/cache@v4
+    uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
     with:
       path: ${{ inputs.path }}
       # Key is a hash of all the .go, .p files.

--- a/cache-rust-binaries/action.yaml
+++ b/cache-rust-binaries/action.yaml
@@ -32,7 +32,7 @@ runs:
 
   - name: Cache rust build binaries
     id: rust_artifact_cache
-    uses: actions/cache@v4
+    uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
     with:
       path: ${{ inputs.path }}
       # Key is a hash of all the .rs, .proto and Cargo.toml files.

--- a/checkout/action.yaml
+++ b/checkout/action.yaml
@@ -36,7 +36,7 @@ runs:
     uses: mobilecoinofficial/gh-actions/install-git@v0
 
   - name: Checkout
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     with:
       submodules: ${{ inputs.submodules }}
       token: ${{ inputs.token }}

--- a/docker-merge-digests/action.yaml
+++ b/docker-merge-digests/action.yaml
@@ -49,11 +49,11 @@ runs:
       merge-multiple: true
 
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
   - name: Generate Docker Tags
     id: docker_meta
-    uses: docker/metadata-action@v5
+    uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
     with:
       flavor: ${{ inputs.flavor }}
       images: ${{ inputs.images }}
@@ -61,7 +61,7 @@ runs:
 
   - name: Login to DockerHub
     if: inputs.username && inputs.password
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
     with:
       username: ${{ inputs.username }}
       password: ${{ inputs.password }}

--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -87,21 +87,21 @@ runs:
   # set up multi-arch support emulation
   - name: Set up QEMU
     if: inputs.emulation == 'true'
-    uses: docker/setup-qemu-action@v3
+    uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
   - name: Login to DockerHub
     if: inputs.username && inputs.password
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
     with:
       username: ${{ inputs.username }}
       password: ${{ inputs.password }}
 
   - name: Publish to DockerHub
     id: build
-    uses: docker/build-push-action@v6
+    uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
     env:
       DOCKER_BUILD_CHECKS_ANNOTATIONS: "false"
       DOCKER_BUILD_SUMMARY: "false"

--- a/download-artifact/action.yaml
+++ b/download-artifact/action.yaml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
   - name: Download Artifacts
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
     with:
       name: ${{ inputs.name }}
       path: ${{ inputs.path }}

--- a/gh-release/action.yaml
+++ b/gh-release/action.yaml
@@ -50,7 +50,7 @@ runs:
   using: composite
   steps:
   - name: Release
-    uses: softprops/action-gh-release@v2
+    uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
     with:
       body: ${{ inputs.body }}
       body_path: ${{ inputs.body_path }}

--- a/lint-actions/action.yaml
+++ b/lint-actions/action.yaml
@@ -16,7 +16,7 @@ runs:
       submodules: ${{ inputs.submodules }}
 
   - name: Run actionlint with reviewdog
-    uses: reviewdog/action-actionlint@v1
+    uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
     with:
       level: error
       reporter: github-pr-review

--- a/lint-docker/action.yaml
+++ b/lint-docker/action.yaml
@@ -22,7 +22,7 @@ runs:
       sudo apt-get install -y wget
 
   - name: Run hadolint with reviewdog
-    uses: reviewdog/action-hadolint@v1
+    uses: reviewdog/action-hadolint@fc7ee4a9f71e521bc43e370819247b70e5327540 # v1.50.2
     with:
       level: error
       reporter: github-pr-review

--- a/lint-shell/action.yaml
+++ b/lint-shell/action.yaml
@@ -22,7 +22,7 @@ runs:
       sudo apt-get install -y xz-utils
 
   - name: Run shellcheck with reviewdog
-    uses: reviewdog/action-shellcheck@v1
+    uses: reviewdog/action-shellcheck@5ebd09ddbe2ebb471646ce234c6c8dd18663ca7c # v1.30.0
     with:
       level: error
       reporter: github-pr-review

--- a/publish-buf/action.yaml
+++ b/publish-buf/action.yaml
@@ -16,12 +16,12 @@ runs:
     uses: mobilecoinofficial/gh-actions/checkout@v0
 
   - name: Buf Setup
-    uses: bufbuild/buf-setup-action@v1
+    uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
     with:
       github_token: ${{ github.token }}
 
   - name: Publish Protobufs to Buf
-    uses: bufbuild/buf-push-action@v1
+    uses: bufbuild/buf-push-action@a654ff18effe4641ebea4a4ce242c49800728459 # v1.2.0
     with:
       # TODO: Reuse GH tag on buf when buf-push-action supports specifying
       # it: https://github.com/bufbuild/buf-push-action/issues/20

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "reviewers": ["team:infrastructure"]
 }

--- a/tag/action.yaml
+++ b/tag/action.yaml
@@ -21,7 +21,7 @@ runs:
       token: ${{ inputs.github_token }}
 
   - name: Bump GitHub tag
-    uses: anothrNick/github-tag-action@v1
+    uses: anothrNick/github-tag-action@f278d49d30cdd8775cc3e7dd00b5ee11686ee297 # v1.71.0
     env:
       GITHUB_TOKEN: ${{ inputs.github_token }}
       WITH_V: ${{ inputs.with_v }}

--- a/upload-artifact/action.yaml
+++ b/upload-artifact/action.yaml
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
   - name: Upload binaries
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
     with:
       name: ${{ inputs.name }}
       path: ${{ inputs.path }}


### PR DESCRIPTION
- Pin upstream action versions to commit sha.
- Add infrastructure team as renovate reviewers. 