### PR TITLE
Use `input.github_token` for cargo audit token

### DIFF
--- a/rustsec-audit-check/action.yaml
+++ b/rustsec-audit-check/action.yaml
@@ -22,4 +22,4 @@ runs:
   - name: run cargo audit
     uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
     with:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ inputs.github_token }}


### PR DESCRIPTION
Previously the `token` specified for the cargo audit action was using
`secrets.GITHUB_TOKEN`. This was incorrect for a workflow dispatch. Now
the `token` is provided via the `input` in the rustsec-audit-check.
