### PR TITLE
lint-markdown: set default to a supported valute

### DIFF
--- a/lint-markdown/action.yaml
+++ b/lint-markdown/action.yaml
@@ -8,7 +8,7 @@ inputs:
     required: false
   fix:
     description: Whether to fix supported issues automatically (any truthy value enables)
-    default: ''
+    default: 'false'
     required: false
   globs:
     description: Glob expression(s) of files to lint (newline-delimited)


### PR DESCRIPTION
I encountered [this](https://github.com/mobilecoinofficial/misty-sign/actions/runs/29467477539/job/87523579781?pr=273) failure and changing `fix` to `false` solves it (see https://github.com/mobilecoinofficial/misty-sign/pull/274)