### PR TITLE
let renovate merge prs after review

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": [
     "config:recommended"
   ],
-  "reviewers": ["team:infrastructure"]
+  "reviewers": ["team:infrastructure"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
 }


### PR DESCRIPTION
Let renovate set PRs to automerge after a review.  This should only take that action on minor, patch version updates.